### PR TITLE
FetchPrebuiltUE4Lib rewritten to have no internal state

### DIFF
--- a/FetchPrebuiltUE4/Program.cs
+++ b/FetchPrebuiltUE4/Program.cs
@@ -6,8 +6,7 @@ namespace FetchPrebuiltUE4
     {
         static int Main(string[] args)
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-            Task<int> result = lib.Run(args);
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(args);
             result.Wait();
             return result.Result;
         }

--- a/FetchPrebuiltUE4Test/AuthCommands.cs
+++ b/FetchPrebuiltUE4Test/AuthCommands.cs
@@ -7,30 +7,12 @@ namespace FetchPrebuiltUE4Test
     {
         private const string CredentialsFile = "application-default-credentials.json";
 
-        private static void WriteConfigFile()
-        {
-            const string content =
-            @"{
-                ""ClientId"" : "" < client ID, for user authentication> "",
-                ""ClientSecret"" : ""<client secret, for user authentication>"",
-                ""BlockStorageURI"": ""<location where blocks will be stored>"",
-                ""VersionIndexStorageURI"": ""<location within which .lvi files will be created>"",
-                ""UE4Folder"" : ""<folder where UE4 is supposed to get downloaded to>""
-            }";
-
-            System.IO.File.WriteAllText("FetchPrebuiltUE4.config.json", content);
-        }
-
         [Fact]
         public void TestClearAuthCommandWhenAuthExists()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
-            WriteConfigFile();
-
             System.IO.File.WriteAllText(CredentialsFile, "hello");
 
-            Task<int> result = lib.Run(new string[] { "clear-auth" });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "clear-auth" });
             result.Wait();
             Assert.Equal(0, result.Result);
 
@@ -40,14 +22,10 @@ namespace FetchPrebuiltUE4Test
         [Fact]
         public void TestClearAuthCommandWhenAuthDoesNotExist()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
-            WriteConfigFile();
-
             if (System.IO.File.Exists(CredentialsFile))
                 System.IO.File.Delete(CredentialsFile);
 
-            Task<int> result = lib.Run(new string[] { "clear-auth" });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "clear-auth" });
             result.Wait();
             Assert.Equal(0, result.Result);
 

--- a/FetchPrebuiltUE4Test/UpdateVersionAgainstLocalStore.cs
+++ b/FetchPrebuiltUE4Test/UpdateVersionAgainstLocalStore.cs
@@ -63,8 +63,6 @@ namespace FetchPrebuiltUE4Test
         [Fact]
         public void UpdateWithDifferentVersion()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
             WriteConfigFile(LocalStoreSource, TestPackage);
             WriteDesiredVersion(PackageName);
             WriteInstalledVersion("");
@@ -74,7 +72,7 @@ namespace FetchPrebuiltUE4Test
             Assert.False(File.Exists(Path.Combine(new string[] { TestPackage, "hello.txt" })));
             Assert.NotEqual(PackageName, ReadInstalledVersion());
 
-            Task<int> result = lib.Run(new string[] { "update-local-ue4-version" });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "update-local-ue4-version" });
             result.Wait();
             Assert.Equal(0, result.Result);
 
@@ -85,8 +83,6 @@ namespace FetchPrebuiltUE4Test
         [Fact]
         public void UpdateWithSameVersion()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
             WriteConfigFile(LocalStoreSource, TestPackage);
             WriteDesiredVersion(PackageName);
             WriteInstalledVersion(PackageName);
@@ -96,7 +92,7 @@ namespace FetchPrebuiltUE4Test
             Assert.False(File.Exists(Path.Combine(new string[] { TestPackage, "hello.txt" })));
             Assert.Equal(PackageName, ReadInstalledVersion());
 
-            Task<int> result = lib.Run(new string[] { "update-local-ue4-version" });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "update-local-ue4-version" });
             result.Wait();
             Assert.Equal(0, result.Result);
 

--- a/FetchPrebuiltUE4Test/UploadAndDownloadToLocalStore.cs
+++ b/FetchPrebuiltUE4Test/UploadAndDownloadToLocalStore.cs
@@ -60,15 +60,13 @@ namespace FetchPrebuiltUE4Test
         [Fact]
         public void TestUpsyncPackageToLocalStore()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
             InitializeLocalStore();
 
             WriteConfigFile(LocalStore);
 
             Assert.False(File.Exists(Path.Combine(new string[] { LocalStore, "versions", $"{PackageName}.lvi" })));
 
-            Task<int> result = lib.Run(new string[] { "upload-package", "--folder", TestPackageSource, "--package", PackageName });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "upload-package", "--folder", TestPackageSource, "--package", PackageName });
             result.Wait();
             Assert.Equal(0, result.Result);
 
@@ -78,15 +76,13 @@ namespace FetchPrebuiltUE4Test
         [Fact]
         public void TestDownsyncPackageFromLocalStore()
         {
-            FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib lib = new FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib();
-
             WriteConfigFile(LocalStoreSource);
 
             InitializeTestPackage();
 
             Assert.False(File.Exists(Path.Combine(new string[] { TestPackage, "hello.txt" })));
 
-            Task<int> result = lib.Run(new string[] { "download-package", "--folder", TestPackage, "--package", PackageName });
+            Task<int> result = FetchPrebuiltUE4Lib.FetchPrebuiltUE4Lib.Run(new string[] { "download-package", "--folder", TestPackage, "--package", PackageName });
             result.Wait();
             Assert.Equal(0, result.Result);
 


### PR DESCRIPTION
There were several bugs regarding initialization. Some commands needed config file parsing to have happened, other commands needed it to not have happened.
By removing all state from FetchPrebuiltUE4Lib, all config file parsing is in-lined with the individual commands and is therefore guaranteed to only happen when necessary.